### PR TITLE
Subclass of PriceList should be Price

### DIFF
--- a/lib/Models/ProductPricing/PriceList.php
+++ b/lib/Models/ProductPricing/PriceList.php
@@ -252,6 +252,6 @@ class PriceList implements ModelInterface, ArrayAccess, IterableType
 
     public function getSubClass()
     {
-        return PriceType::class;
+        return Price::class;
     }
 }


### PR DESCRIPTION
The getPricing operation is not working because the subclass of PriceList is PriceType, which is not correct. It should be [Price](https://github.com/amzn/selling-partner-api-docs/blob/main/references/product-pricing-api/productPricingV0.md#price). Updating the subclass resolves this issue.