### PR TITLE
to properly deserialize inventorySummaries the function getSubClass w…

### DIFF
--- a/lib/Models/FbaInventory/InventorySummaries.php
+++ b/lib/Models/FbaInventory/InventorySummaries.php
@@ -251,4 +251,9 @@ class InventorySummaries implements ModelInterface, ArrayAccess
 
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
+
+    public function getSubClass()
+    {
+        return InventorySummary::class;
+    }
 }


### PR DESCRIPTION
As discussed in issue: https://github.com/clousale/amazon-sp-api-php/issues/69
The inventorysummaries from the FBAInventory call was not properly deserialized. This is the fix for it.