### PR TITLE
Add JPY to CurrencyCode

### DIFF
--- a/lib/Models/FulfillmentInbound/CurrencyCode.php
+++ b/lib/Models/FulfillmentInbound/CurrencyCode.php
@@ -20,7 +20,6 @@ namespace ClouSale\AmazonSellingPartnerAPI\Models\FulfillmentInbound;
 /**
  * CurrencyCode Class Doc Comment.
  *
-
  * @description The currency code.
  *
  * @author   Stefan Neuhaus / ClouSale
@@ -32,6 +31,7 @@ class CurrencyCode
      */
     const USD = 'USD';
     const GBP = 'GBP';
+    const JPY = 'JPY';
 
     /**
      * Gets allowable values of the enum.
@@ -42,6 +42,8 @@ class CurrencyCode
     {
         return [
             self::USD,
-self::GBP,        ];
+            self::GBP,
+            self::JPY
+        ];
     }
 }


### PR DESCRIPTION
Hello.
When I run **getPrepInstructions Operation** in **Selling Partner API for Fulfillment Inbound**, if I set ShipToCountryCode to JP, the CurrencyCode is returned in JPY.

The result is
> InvalidArgumentException: Invalid value for enum '\ClouSale\AmazonSellingPartnerAPI\Models\FulfillmentInbound\CurrencyCode', must be one of of: 'USD', 'GBP'. 

Therefore, we added JPY to the CurrencyCode.

Execution Result
```array(3) {
  ["SKUPrepInstructionsList"]=>
  array(1) {
    [0]=>
    array(6) {
      ["SellerSKU"]=>
      string(25) "XXXXXXXXXXXXXXXXXXXXXXXXX"
      ["ASIN"]=>
      string(10) "B07BWL29TP"
      ["BarcodeInstruction"]=>
      string(18) "RequiresFNSKULabel"
      ["PrepGuidance"]=>
      string(24) "NoAdditionalPrepRequired"
      ["PrepInstructionList"]=>
      array(1) {
        [0]=>
        string(8) "Labeling"
      }
      ["AmazonPrepFeesDetailsList"]=>
      array(1) {
        [0]=>
        array(2) {
          ["PrepInstruction"]=>
          string(8) "Labeling"
          ["FeePerUnit"]=>
          array(2) {
            ["CurrencyCode"]=>
            string(3) "JPY"
            ["Value"]=>
            array(0) {
            }
          }
        }
      }
    }
  }
  ["InvalidSKUList"]=>
  array(0) {
  }
}
```