### PR TITLE
Normalize uri parts solve error on fba/outbound/2020-07-01/fulfillmentOrders

### DIFF
--- a/lib/Signature.php
+++ b/lib/Signature.php
@@ -73,6 +73,11 @@ class Signature
         $amzdate = gmdate('Ymd\THis\Z');
         $date = substr($amzdate, 0, 8);
 
+        // Normalize uri parts for order number which contains special chars (fba/outbound/2020-07-01/fulfillmentOrders)
+        $uri = implode('/', array_map(function ($chunk) {
+            return urlencode($chunk);
+        }, explode('/', $uri)));
+        
         // Prepare payload
         if (is_array($data)) {
             $param = json_encode($data);


### PR DESCRIPTION
it happens only when a GET request have a URI with special chars
the uri contains the order number, the order number contains a special char :
origin -> AAA:123-1234567-1234567
1 x urlencode -> AAA%3A123-1234567-1234567
2 x urlencode -> AAA%253A123-1234567-1234567

long story short, urlencode is done one time, but needs to be double, one here and one on HTTP Client and must be done per single part not the whole $uri.

I find it here : https://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html
at point 2 of the Spec.

Test Case : 
/fba/outbound/2020-07-01/fulfillmentOrders/AAA%3A123-1234567-1234567 => result in 403 Forbidden
/fba/outbound/2020-07-01/fulfillmentOrders/AAA%253A123-1234567-1234567 => result in correct response