### PR TITLE
Removed 'parent::listInvalidProperties'

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,9 @@
     "license": "MIT",
     "authors": [
         {
+            "name": "PayNow"
+        },
+        {
             "name": "ClouSale",
             "homepage": "https://www.clousale.com"
         }

--- a/lib/Helpers/SellingPartnerApiRequest.php
+++ b/lib/Helpers/SellingPartnerApiRequest.php
@@ -122,13 +122,12 @@ trait SellingPartnerApiRequest
                     $content = json_decode($content);
                 }
             }
-//            var_dump($content);
-//            exit();
 
             return [
                 ObjectSerializer::deserialize($content, $returnType, []),
                 $response->getStatusCode(),
                 $response->getHeaders(),
+                $content,
             ];
         } catch (ApiException $e) {
             switch ($e->getCode()) {

--- a/lib/Models/Authorization/AuthorizationCode.php
+++ b/lib/Models/Authorization/AuthorizationCode.php
@@ -167,9 +167,7 @@ class AuthorizationCode implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Authorization/ErrorList.php
+++ b/lib/Models/Authorization/ErrorList.php
@@ -167,9 +167,7 @@ class ErrorList implements ModelInterface, ArrayAccess, IterableType
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Authorization/GetAuthorizationCodeResponse.php
+++ b/lib/Models/Authorization/GetAuthorizationCodeResponse.php
@@ -173,9 +173,7 @@ class GetAuthorizationCodeResponse implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Catalog/AttributeSetList.php
+++ b/lib/Models/Catalog/AttributeSetList.php
@@ -167,9 +167,7 @@ class AttributeSetList extends Categories implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Catalog/AttributeSetListType.php
+++ b/lib/Models/Catalog/AttributeSetListType.php
@@ -737,9 +737,7 @@ class AttributeSetListType extends Categories implements ModelInterface, ArrayAc
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Catalog/Categories.php
+++ b/lib/Models/Catalog/Categories.php
@@ -176,9 +176,7 @@ class Categories implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Catalog/CreatorType.php
+++ b/lib/Models/Catalog/CreatorType.php
@@ -173,9 +173,7 @@ class CreatorType extends Categories implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Catalog/DecimalWithUnits.php
+++ b/lib/Models/Catalog/DecimalWithUnits.php
@@ -173,9 +173,7 @@ class DecimalWithUnits extends Categories implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Catalog/DimensionType.php
+++ b/lib/Models/Catalog/DimensionType.php
@@ -185,9 +185,7 @@ class DimensionType extends Categories implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Catalog/ErrorList.php
+++ b/lib/Models/Catalog/ErrorList.php
@@ -167,9 +167,7 @@ class ErrorList extends Categories implements ModelInterface, ArrayAccess, Itera
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Catalog/GetCatalogItemResponse.php
+++ b/lib/Models/Catalog/GetCatalogItemResponse.php
@@ -170,9 +170,7 @@ class GetCatalogItemResponse extends Categories implements ModelInterface, Array
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Catalog/IdentifierType.php
+++ b/lib/Models/Catalog/IdentifierType.php
@@ -170,9 +170,7 @@ class IdentifierType extends Categories implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Catalog/Image.php
+++ b/lib/Models/Catalog/Image.php
@@ -179,9 +179,7 @@ class Image extends Categories implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Catalog/ItemList.php
+++ b/lib/Models/Catalog/ItemList.php
@@ -166,9 +166,7 @@ class ItemList extends Categories implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Catalog/LanguageType.php
+++ b/lib/Models/Catalog/LanguageType.php
@@ -179,9 +179,7 @@ class LanguageType extends Categories implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Catalog/ListCatalogCategoriesResponse.php
+++ b/lib/Models/Catalog/ListCatalogCategoriesResponse.php
@@ -170,9 +170,7 @@ class ListCatalogCategoriesResponse extends Categories implements ModelInterface
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Catalog/ListCatalogItemsResponse.php
+++ b/lib/Models/Catalog/ListCatalogItemsResponse.php
@@ -170,9 +170,7 @@ class ListCatalogItemsResponse extends Categories implements ModelInterface, Arr
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Catalog/ListMatchingItemsResponse.php
+++ b/lib/Models/Catalog/ListMatchingItemsResponse.php
@@ -164,9 +164,7 @@ class ListMatchingItemsResponse extends Categories implements ModelInterface, Ar
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Catalog/ListOfCategories.php
+++ b/lib/Models/Catalog/ListOfCategories.php
@@ -163,9 +163,7 @@ class ListOfCategories extends Categories implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Catalog/NumberOfOfferListingsList.php
+++ b/lib/Models/Catalog/NumberOfOfferListingsList.php
@@ -167,9 +167,7 @@ class NumberOfOfferListingsList extends Categories implements ModelInterface, Ar
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Catalog/Price.php
+++ b/lib/Models/Catalog/Price.php
@@ -173,9 +173,7 @@ class Price extends Categories implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Catalog/RelationshipList.php
+++ b/lib/Models/Catalog/RelationshipList.php
@@ -167,9 +167,7 @@ class RelationshipList extends Categories implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Catalog/RelationshipType.php
+++ b/lib/Models/Catalog/RelationshipType.php
@@ -293,9 +293,7 @@ class RelationshipType extends Categories implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Catalog/SalesRankList.php
+++ b/lib/Models/Catalog/SalesRankList.php
@@ -167,9 +167,7 @@ class SalesRankList extends Categories implements ModelInterface, ArrayAccess, I
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Catalog/ShippingTimeType.php
+++ b/lib/Models/Catalog/ShippingTimeType.php
@@ -164,9 +164,7 @@ class ShippingTimeType extends Categories implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FbaInboundEligibility/ErrorList.php
+++ b/lib/Models/FbaInboundEligibility/ErrorList.php
@@ -167,9 +167,7 @@ class ErrorList implements ModelInterface, ArrayAccess, IterableType
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FbaInboundEligibility/GetItemEligibilityPreviewResponse.php
+++ b/lib/Models/FbaInboundEligibility/GetItemEligibilityPreviewResponse.php
@@ -173,9 +173,7 @@ class GetItemEligibilityPreviewResponse implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FbaInventory/ErrorList.php
+++ b/lib/Models/FbaInventory/ErrorList.php
@@ -167,9 +167,7 @@ class ErrorList implements ModelInterface, ArrayAccess, IterableType
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FbaInventory/GetInventorySummariesResponse.php
+++ b/lib/Models/FbaInventory/GetInventorySummariesResponse.php
@@ -179,9 +179,7 @@ class GetInventorySummariesResponse implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FbaInventory/InventoryDetails.php
+++ b/lib/Models/FbaInventory/InventoryDetails.php
@@ -203,9 +203,7 @@ class InventoryDetails implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FbaInventory/InventorySummaries.php
+++ b/lib/Models/FbaInventory/InventorySummaries.php
@@ -166,9 +166,7 @@ class InventorySummaries implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FbaInventory/InventorySummary.php
+++ b/lib/Models/FbaInventory/InventorySummary.php
@@ -209,9 +209,7 @@ class InventorySummary implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FbaInventory/Pagination.php
+++ b/lib/Models/FbaInventory/Pagination.php
@@ -167,9 +167,7 @@ class Pagination implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FbaInventory/ResearchingQuantity.php
+++ b/lib/Models/FbaInventory/ResearchingQuantity.php
@@ -173,9 +173,7 @@ class ResearchingQuantity implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FbaInventory/ReservedQuantity.php
+++ b/lib/Models/FbaInventory/ReservedQuantity.php
@@ -185,9 +185,7 @@ class ReservedQuantity implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FbaInventory/UnfulfillableQuantity.php
+++ b/lib/Models/FbaInventory/UnfulfillableQuantity.php
@@ -203,9 +203,7 @@ class UnfulfillableQuantity implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FbaSmallAndLight/ErrorList.php
+++ b/lib/Models/FbaSmallAndLight/ErrorList.php
@@ -168,9 +168,7 @@ class ErrorList implements ModelInterface, ArrayAccess, IterableType
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FbaSmallAndLight/FeePreview.php
+++ b/lib/Models/FbaSmallAndLight/FeePreview.php
@@ -191,9 +191,7 @@ class FeePreview implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FbaSmallAndLight/MarketplaceId.php
+++ b/lib/Models/FbaSmallAndLight/MarketplaceId.php
@@ -166,9 +166,7 @@ class MarketplaceId implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FbaSmallAndLight/MoneyType.php
+++ b/lib/Models/FbaSmallAndLight/MoneyType.php
@@ -170,9 +170,7 @@ class MoneyType implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FbaSmallAndLight/SellerSKU.php
+++ b/lib/Models/FbaSmallAndLight/SellerSKU.php
@@ -166,9 +166,7 @@ class SellerSKU implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FbaSmallAndLight/SmallAndLightFeePreviews.php
+++ b/lib/Models/FbaSmallAndLight/SmallAndLightFeePreviews.php
@@ -164,9 +164,7 @@ class SmallAndLightFeePreviews implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Feeds/CancelFeedResponse.php
+++ b/lib/Models/Feeds/CancelFeedResponse.php
@@ -167,9 +167,7 @@ class CancelFeedResponse implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Feeds/CreateFeedDocumentResponse.php
+++ b/lib/Models/Feeds/CreateFeedDocumentResponse.php
@@ -173,9 +173,7 @@ class CreateFeedDocumentResponse implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Feeds/CreateFeedResponse.php
+++ b/lib/Models/Feeds/CreateFeedResponse.php
@@ -173,9 +173,7 @@ class CreateFeedResponse implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Feeds/ErrorList.php
+++ b/lib/Models/Feeds/ErrorList.php
@@ -167,9 +167,7 @@ class ErrorList implements ModelInterface, ArrayAccess, IterableType
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Feeds/FeedList.php
+++ b/lib/Models/Feeds/FeedList.php
@@ -164,9 +164,7 @@ class FeedList implements ModelInterface, ArrayAccess, IterableType
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Feeds/FeedOptions.php
+++ b/lib/Models/Feeds/FeedOptions.php
@@ -166,9 +166,7 @@ class FeedOptions implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Feeds/GetFeedDocumentResponse.php
+++ b/lib/Models/Feeds/GetFeedDocumentResponse.php
@@ -173,9 +173,7 @@ class GetFeedDocumentResponse implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Feeds/GetFeedResponse.php
+++ b/lib/Models/Feeds/GetFeedResponse.php
@@ -173,9 +173,7 @@ class GetFeedResponse implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Feeds/GetFeedsResponse.php
+++ b/lib/Models/Feeds/GetFeedsResponse.php
@@ -179,9 +179,7 @@ class GetFeedsResponse implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Finances/AdjustmentEvent.php
+++ b/lib/Models/Finances/AdjustmentEvent.php
@@ -185,9 +185,7 @@ class AdjustmentEvent implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Finances/AdjustmentEventList.php
+++ b/lib/Models/Finances/AdjustmentEventList.php
@@ -167,9 +167,7 @@ class AdjustmentEventList implements ModelInterface, ArrayAccess, IterableType
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Finances/AdjustmentItem.php
+++ b/lib/Models/Finances/AdjustmentItem.php
@@ -203,9 +203,7 @@ class AdjustmentItem implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Finances/AdjustmentItemList.php
+++ b/lib/Models/Finances/AdjustmentItemList.php
@@ -167,9 +167,7 @@ class AdjustmentItemList implements ModelInterface, ArrayAccess, IterableType
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Finances/AffordabilityExpenseEventList.php
+++ b/lib/Models/Finances/AffordabilityExpenseEventList.php
@@ -167,9 +167,7 @@ class AffordabilityExpenseEventList implements ModelInterface, ArrayAccess, Iter
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Finances/BigDecimal.php
+++ b/lib/Models/Finances/BigDecimal.php
@@ -163,9 +163,7 @@ class BigDecimal implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Finances/ChargeComponent.php
+++ b/lib/Models/Finances/ChargeComponent.php
@@ -173,9 +173,7 @@ class ChargeComponent implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Finances/ChargeComponentList.php
+++ b/lib/Models/Finances/ChargeComponentList.php
@@ -167,9 +167,7 @@ class ChargeComponentList implements ModelInterface, ArrayAccess, IterableType
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Finances/ChargeInstrument.php
+++ b/lib/Models/Finances/ChargeInstrument.php
@@ -179,9 +179,7 @@ class ChargeInstrument implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Finances/ChargeInstrumentList.php
+++ b/lib/Models/Finances/ChargeInstrumentList.php
@@ -167,9 +167,7 @@ class ChargeInstrumentList implements ModelInterface, ArrayAccess, IterableType
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Finances/CouponPaymentEvent.php
+++ b/lib/Models/Finances/CouponPaymentEvent.php
@@ -209,9 +209,7 @@ class CouponPaymentEvent implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Finances/CouponPaymentEventList.php
+++ b/lib/Models/Finances/CouponPaymentEventList.php
@@ -167,9 +167,7 @@ class CouponPaymentEventList implements ModelInterface, ArrayAccess, IterableTyp
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Finances/Currency.php
+++ b/lib/Models/Finances/Currency.php
@@ -173,9 +173,7 @@ class Currency implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Finances/Date.php
+++ b/lib/Models/Finances/Date.php
@@ -163,9 +163,7 @@ class Date implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Finances/DebtRecoveryEvent.php
+++ b/lib/Models/Finances/DebtRecoveryEvent.php
@@ -191,9 +191,7 @@ class DebtRecoveryEvent implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Finances/DebtRecoveryEventList.php
+++ b/lib/Models/Finances/DebtRecoveryEventList.php
@@ -167,9 +167,7 @@ class DebtRecoveryEventList implements ModelInterface, ArrayAccess, IterableType
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Finances/DebtRecoveryItem.php
+++ b/lib/Models/Finances/DebtRecoveryItem.php
@@ -185,9 +185,7 @@ class DebtRecoveryItem implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Finances/DebtRecoveryItemList.php
+++ b/lib/Models/Finances/DebtRecoveryItemList.php
@@ -167,9 +167,7 @@ class DebtRecoveryItemList implements ModelInterface, ArrayAccess, IterableType
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Finances/DirectPayment.php
+++ b/lib/Models/Finances/DirectPayment.php
@@ -173,9 +173,7 @@ class DirectPayment implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Finances/DirectPaymentList.php
+++ b/lib/Models/Finances/DirectPaymentList.php
@@ -167,9 +167,7 @@ class DirectPaymentList implements ModelInterface, ArrayAccess, IterableType
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Finances/ErrorList.php
+++ b/lib/Models/Finances/ErrorList.php
@@ -167,9 +167,7 @@ class ErrorList implements ModelInterface, ArrayAccess, IterableType
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Finances/FBALiquidationEvent.php
+++ b/lib/Models/Finances/FBALiquidationEvent.php
@@ -185,9 +185,7 @@ class FBALiquidationEvent implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Finances/FBALiquidationEventList.php
+++ b/lib/Models/Finances/FBALiquidationEventList.php
@@ -167,9 +167,7 @@ class FBALiquidationEventList implements ModelInterface, ArrayAccess, IterableTy
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Finances/FeeComponent.php
+++ b/lib/Models/Finances/FeeComponent.php
@@ -173,9 +173,7 @@ class FeeComponent implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Finances/FeeComponentList.php
+++ b/lib/Models/Finances/FeeComponentList.php
@@ -167,9 +167,7 @@ class FeeComponentList implements ModelInterface, ArrayAccess, IterableType
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Finances/FinancialEventGroup.php
+++ b/lib/Models/Finances/FinancialEventGroup.php
@@ -227,9 +227,7 @@ class FinancialEventGroup implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Finances/FinancialEventGroupList.php
+++ b/lib/Models/Finances/FinancialEventGroupList.php
@@ -167,9 +167,7 @@ class FinancialEventGroupList implements ModelInterface, ArrayAccess, IterableTy
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Finances/FinancialEvents.php
+++ b/lib/Models/Finances/FinancialEvents.php
@@ -293,9 +293,7 @@ class FinancialEvents implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Finances/ImagingServicesFeeEvent.php
+++ b/lib/Models/Finances/ImagingServicesFeeEvent.php
@@ -185,9 +185,7 @@ class ImagingServicesFeeEvent implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Finances/ImagingServicesFeeEventList.php
+++ b/lib/Models/Finances/ImagingServicesFeeEventList.php
@@ -167,9 +167,7 @@ class ImagingServicesFeeEventList implements ModelInterface, ArrayAccess, Iterab
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Finances/ListFinancialEventGroupsPayload.php
+++ b/lib/Models/Finances/ListFinancialEventGroupsPayload.php
@@ -173,9 +173,7 @@ class ListFinancialEventGroupsPayload implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Finances/ListFinancialEventGroupsResponse.php
+++ b/lib/Models/Finances/ListFinancialEventGroupsResponse.php
@@ -173,9 +173,7 @@ class ListFinancialEventGroupsResponse implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Finances/ListFinancialEventsPayload.php
+++ b/lib/Models/Finances/ListFinancialEventsPayload.php
@@ -173,9 +173,7 @@ class ListFinancialEventsPayload implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Finances/ListFinancialEventsResponse.php
+++ b/lib/Models/Finances/ListFinancialEventsResponse.php
@@ -173,9 +173,7 @@ class ListFinancialEventsResponse implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Finances/LoanServicingEvent.php
+++ b/lib/Models/Finances/LoanServicingEvent.php
@@ -173,9 +173,7 @@ class LoanServicingEvent implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Finances/LoanServicingEventList.php
+++ b/lib/Models/Finances/LoanServicingEventList.php
@@ -167,9 +167,7 @@ class LoanServicingEventList implements ModelInterface, ArrayAccess, IterableTyp
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Finances/NetworkComminglingTransactionEvent.php
+++ b/lib/Models/Finances/NetworkComminglingTransactionEvent.php
@@ -209,9 +209,7 @@ class NetworkComminglingTransactionEvent implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Finances/NetworkComminglingTransactionEventList.php
+++ b/lib/Models/Finances/NetworkComminglingTransactionEventList.php
@@ -167,9 +167,7 @@ class NetworkComminglingTransactionEventList implements ModelInterface, ArrayAcc
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Finances/PayWithAmazonEvent.php
+++ b/lib/Models/Finances/PayWithAmazonEvent.php
@@ -221,9 +221,7 @@ class PayWithAmazonEvent implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Finances/PayWithAmazonEventList.php
+++ b/lib/Models/Finances/PayWithAmazonEventList.php
@@ -167,9 +167,7 @@ class PayWithAmazonEventList implements ModelInterface, ArrayAccess, IterableTyp
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Finances/ProductAdsPaymentEvent.php
+++ b/lib/Models/Finances/ProductAdsPaymentEvent.php
@@ -197,9 +197,7 @@ class ProductAdsPaymentEvent implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Finances/ProductAdsPaymentEventList.php
+++ b/lib/Models/Finances/ProductAdsPaymentEventList.php
@@ -167,9 +167,7 @@ class ProductAdsPaymentEventList implements ModelInterface, ArrayAccess, Iterabl
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Finances/Promotion.php
+++ b/lib/Models/Finances/Promotion.php
@@ -179,9 +179,7 @@ class Promotion implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Finances/PromotionList.php
+++ b/lib/Models/Finances/PromotionList.php
@@ -167,9 +167,7 @@ class PromotionList implements ModelInterface, ArrayAccess, IterableType
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Finances/RemovalShipmentEvent.php
+++ b/lib/Models/Finances/RemovalShipmentEvent.php
@@ -185,9 +185,7 @@ class RemovalShipmentEvent implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Finances/RemovalShipmentEventList.php
+++ b/lib/Models/Finances/RemovalShipmentEventList.php
@@ -167,9 +167,7 @@ class RemovalShipmentEventList implements ModelInterface, ArrayAccess, IterableT
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Finances/RemovalShipmentItem.php
+++ b/lib/Models/Finances/RemovalShipmentItem.php
@@ -209,9 +209,7 @@ class RemovalShipmentItem implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Finances/RemovalShipmentItemList.php
+++ b/lib/Models/Finances/RemovalShipmentItemList.php
@@ -167,9 +167,7 @@ class RemovalShipmentItemList implements ModelInterface, ArrayAccess, IterableTy
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Finances/RentalTransactionEvent.php
+++ b/lib/Models/Finances/RentalTransactionEvent.php
@@ -221,9 +221,7 @@ class RentalTransactionEvent implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Finances/RentalTransactionEventList.php
+++ b/lib/Models/Finances/RentalTransactionEventList.php
@@ -167,9 +167,7 @@ class RentalTransactionEventList implements ModelInterface, ArrayAccess, Iterabl
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Finances/RetrochargeEvent.php
+++ b/lib/Models/Finances/RetrochargeEvent.php
@@ -203,9 +203,7 @@ class RetrochargeEvent implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Finances/RetrochargeEventList.php
+++ b/lib/Models/Finances/RetrochargeEventList.php
@@ -167,9 +167,7 @@ class RetrochargeEventList implements ModelInterface, ArrayAccess, IterableType
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Finances/SAFETReimbursementEvent.php
+++ b/lib/Models/Finances/SAFETReimbursementEvent.php
@@ -191,9 +191,7 @@ class SAFETReimbursementEvent implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Finances/SAFETReimbursementEventList.php
+++ b/lib/Models/Finances/SAFETReimbursementEventList.php
@@ -167,9 +167,7 @@ class SAFETReimbursementEventList implements ModelInterface, ArrayAccess, Iterab
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Finances/SAFETReimbursementItem.php
+++ b/lib/Models/Finances/SAFETReimbursementItem.php
@@ -179,9 +179,7 @@ class SAFETReimbursementItem implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Finances/SAFETReimbursementItemList.php
+++ b/lib/Models/Finances/SAFETReimbursementItemList.php
@@ -167,9 +167,7 @@ class SAFETReimbursementItemList implements ModelInterface, ArrayAccess, Iterabl
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Finances/SellerDealPaymentEvent.php
+++ b/lib/Models/Finances/SellerDealPaymentEvent.php
@@ -209,9 +209,7 @@ class SellerDealPaymentEvent implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Finances/SellerDealPaymentEventList.php
+++ b/lib/Models/Finances/SellerDealPaymentEventList.php
@@ -167,9 +167,7 @@ class SellerDealPaymentEventList implements ModelInterface, ArrayAccess, Iterabl
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Finances/SellerReviewEnrollmentPaymentEvent.php
+++ b/lib/Models/Finances/SellerReviewEnrollmentPaymentEvent.php
@@ -197,9 +197,7 @@ class SellerReviewEnrollmentPaymentEvent implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Finances/SellerReviewEnrollmentPaymentEventList.php
+++ b/lib/Models/Finances/SellerReviewEnrollmentPaymentEventList.php
@@ -167,9 +167,7 @@ class SellerReviewEnrollmentPaymentEventList implements ModelInterface, ArrayAcc
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Finances/ServiceFeeEvent.php
+++ b/lib/Models/Finances/ServiceFeeEvent.php
@@ -203,9 +203,7 @@ class ServiceFeeEvent implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Finances/ServiceFeeEventList.php
+++ b/lib/Models/Finances/ServiceFeeEventList.php
@@ -167,9 +167,7 @@ class ServiceFeeEventList implements ModelInterface, ArrayAccess, IterableType
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Finances/ShipmentEvent.php
+++ b/lib/Models/Finances/ShipmentEvent.php
@@ -239,9 +239,7 @@ class ShipmentEvent implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Finances/ShipmentEventList.php
+++ b/lib/Models/Finances/ShipmentEventList.php
@@ -167,9 +167,7 @@ class ShipmentEventList implements ModelInterface, ArrayAccess, IterableType
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Finances/ShipmentItem.php
+++ b/lib/Models/Finances/ShipmentItem.php
@@ -239,9 +239,7 @@ class ShipmentItem implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Finances/ShipmentItemList.php
+++ b/lib/Models/Finances/ShipmentItemList.php
@@ -167,9 +167,7 @@ class ShipmentItemList implements ModelInterface, ArrayAccess, IterableType
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Finances/SolutionProviderCreditEvent.php
+++ b/lib/Models/Finances/SolutionProviderCreditEvent.php
@@ -221,9 +221,7 @@ class SolutionProviderCreditEvent implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Finances/SolutionProviderCreditEventList.php
+++ b/lib/Models/Finances/SolutionProviderCreditEventList.php
@@ -167,9 +167,7 @@ class SolutionProviderCreditEventList implements ModelInterface, ArrayAccess, It
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Finances/TDSReimbursementEvent.php
+++ b/lib/Models/Finances/TDSReimbursementEvent.php
@@ -179,9 +179,7 @@ class TDSReimbursementEvent implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Finances/TDSReimbursementEventList.php
+++ b/lib/Models/Finances/TDSReimbursementEventList.php
@@ -167,9 +167,7 @@ class TDSReimbursementEventList implements ModelInterface, ArrayAccess, Iterable
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Finances/TaxWithheldComponent.php
+++ b/lib/Models/Finances/TaxWithheldComponent.php
@@ -173,9 +173,7 @@ class TaxWithheldComponent implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Finances/TaxWithheldComponentList.php
+++ b/lib/Models/Finances/TaxWithheldComponentList.php
@@ -167,9 +167,7 @@ class TaxWithheldComponentList implements ModelInterface, ArrayAccess, IterableT
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Finances/TrialShipmentEvent.php
+++ b/lib/Models/Finances/TrialShipmentEvent.php
@@ -191,9 +191,7 @@ class TrialShipmentEvent implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Finances/TrialShipmentEventList.php
+++ b/lib/Models/Finances/TrialShipmentEventList.php
@@ -167,9 +167,7 @@ class TrialShipmentEventList implements ModelInterface, ArrayAccess, IterableTyp
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FulfillmentInbound/ASINInboundGuidanceList.php
+++ b/lib/Models/FulfillmentInbound/ASINInboundGuidanceList.php
@@ -167,9 +167,7 @@ class ASINInboundGuidanceList implements ModelInterface, ArrayAccess, IterableTy
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FulfillmentInbound/ASINPrepInstructions.php
+++ b/lib/Models/FulfillmentInbound/ASINPrepInstructions.php
@@ -185,9 +185,7 @@ class ASINPrepInstructions implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FulfillmentInbound/ASINPrepInstructionsList.php
+++ b/lib/Models/FulfillmentInbound/ASINPrepInstructionsList.php
@@ -167,9 +167,7 @@ class ASINPrepInstructionsList implements ModelInterface, ArrayAccess, IterableT
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FulfillmentInbound/AmazonPrepFeesDetails.php
+++ b/lib/Models/FulfillmentInbound/AmazonPrepFeesDetails.php
@@ -173,9 +173,7 @@ class AmazonPrepFeesDetails implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FulfillmentInbound/AmazonPrepFeesDetailsList.php
+++ b/lib/Models/FulfillmentInbound/AmazonPrepFeesDetailsList.php
@@ -167,9 +167,7 @@ class AmazonPrepFeesDetailsList implements ModelInterface, ArrayAccess, Iterable
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FulfillmentInbound/BigDecimalType.php
+++ b/lib/Models/FulfillmentInbound/BigDecimalType.php
@@ -163,9 +163,7 @@ class BigDecimalType implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FulfillmentInbound/BillOfLadingDownloadURL.php
+++ b/lib/Models/FulfillmentInbound/BillOfLadingDownloadURL.php
@@ -164,9 +164,7 @@ class BillOfLadingDownloadURL implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FulfillmentInbound/BoxContentsFeeDetails.php
+++ b/lib/Models/FulfillmentInbound/BoxContentsFeeDetails.php
@@ -179,9 +179,7 @@ class BoxContentsFeeDetails implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FulfillmentInbound/CommonTransportResult.php
+++ b/lib/Models/FulfillmentInbound/CommonTransportResult.php
@@ -164,9 +164,7 @@ class CommonTransportResult implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FulfillmentInbound/ConfirmPreorderResponse.php
+++ b/lib/Models/FulfillmentInbound/ConfirmPreorderResponse.php
@@ -173,9 +173,7 @@ class ConfirmPreorderResponse implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FulfillmentInbound/ConfirmPreorderResult.php
+++ b/lib/Models/FulfillmentInbound/ConfirmPreorderResult.php
@@ -170,9 +170,7 @@ class ConfirmPreorderResult implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FulfillmentInbound/ConfirmTransportResponse.php
+++ b/lib/Models/FulfillmentInbound/ConfirmTransportResponse.php
@@ -173,9 +173,7 @@ class ConfirmTransportResponse implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FulfillmentInbound/CreateInboundShipmentPlanResponse.php
+++ b/lib/Models/FulfillmentInbound/CreateInboundShipmentPlanResponse.php
@@ -173,9 +173,7 @@ class CreateInboundShipmentPlanResponse implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FulfillmentInbound/CreateInboundShipmentPlanResult.php
+++ b/lib/Models/FulfillmentInbound/CreateInboundShipmentPlanResult.php
@@ -164,9 +164,7 @@ class CreateInboundShipmentPlanResult implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FulfillmentInbound/DateStringType.php
+++ b/lib/Models/FulfillmentInbound/DateStringType.php
@@ -163,9 +163,7 @@ class DateStringType implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FulfillmentInbound/ErrorList.php
+++ b/lib/Models/FulfillmentInbound/ErrorList.php
@@ -167,9 +167,7 @@ class ErrorList implements ModelInterface, ArrayAccess, IterableType
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FulfillmentInbound/EstimateTransportResponse.php
+++ b/lib/Models/FulfillmentInbound/EstimateTransportResponse.php
@@ -173,9 +173,7 @@ class EstimateTransportResponse implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FulfillmentInbound/GetBillOfLadingResponse.php
+++ b/lib/Models/FulfillmentInbound/GetBillOfLadingResponse.php
@@ -173,9 +173,7 @@ class GetBillOfLadingResponse implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FulfillmentInbound/GetInboundGuidanceResponse.php
+++ b/lib/Models/FulfillmentInbound/GetInboundGuidanceResponse.php
@@ -173,9 +173,7 @@ class GetInboundGuidanceResponse implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FulfillmentInbound/GetInboundGuidanceResult.php
+++ b/lib/Models/FulfillmentInbound/GetInboundGuidanceResult.php
@@ -182,9 +182,7 @@ class GetInboundGuidanceResult implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FulfillmentInbound/GetLabelsResponse.php
+++ b/lib/Models/FulfillmentInbound/GetLabelsResponse.php
@@ -173,9 +173,7 @@ class GetLabelsResponse implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FulfillmentInbound/GetPreorderInfoResponse.php
+++ b/lib/Models/FulfillmentInbound/GetPreorderInfoResponse.php
@@ -173,9 +173,7 @@ class GetPreorderInfoResponse implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FulfillmentInbound/GetPreorderInfoResult.php
+++ b/lib/Models/FulfillmentInbound/GetPreorderInfoResult.php
@@ -182,9 +182,7 @@ class GetPreorderInfoResult implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FulfillmentInbound/GetPrepInstructionsResponse.php
+++ b/lib/Models/FulfillmentInbound/GetPrepInstructionsResponse.php
@@ -173,9 +173,7 @@ class GetPrepInstructionsResponse implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FulfillmentInbound/GetPrepInstructionsResult.php
+++ b/lib/Models/FulfillmentInbound/GetPrepInstructionsResult.php
@@ -182,9 +182,7 @@ class GetPrepInstructionsResult implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FulfillmentInbound/GetShipmentItemsResponse.php
+++ b/lib/Models/FulfillmentInbound/GetShipmentItemsResponse.php
@@ -173,9 +173,7 @@ class GetShipmentItemsResponse implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FulfillmentInbound/GetShipmentItemsResult.php
+++ b/lib/Models/FulfillmentInbound/GetShipmentItemsResult.php
@@ -170,9 +170,7 @@ class GetShipmentItemsResult implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FulfillmentInbound/GetShipmentsResponse.php
+++ b/lib/Models/FulfillmentInbound/GetShipmentsResponse.php
@@ -173,9 +173,7 @@ class GetShipmentsResponse implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FulfillmentInbound/GetShipmentsResult.php
+++ b/lib/Models/FulfillmentInbound/GetShipmentsResult.php
@@ -170,9 +170,7 @@ class GetShipmentsResult implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FulfillmentInbound/GetTransportDetailsResponse.php
+++ b/lib/Models/FulfillmentInbound/GetTransportDetailsResponse.php
@@ -173,9 +173,7 @@ class GetTransportDetailsResponse implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FulfillmentInbound/GetTransportDetailsResult.php
+++ b/lib/Models/FulfillmentInbound/GetTransportDetailsResult.php
@@ -164,9 +164,7 @@ class GetTransportDetailsResult implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FulfillmentInbound/GuidanceReasonList.php
+++ b/lib/Models/FulfillmentInbound/GuidanceReasonList.php
@@ -167,9 +167,7 @@ class GuidanceReasonList implements ModelInterface, ArrayAccess, IterableType
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FulfillmentInbound/InboundShipmentItemList.php
+++ b/lib/Models/FulfillmentInbound/InboundShipmentItemList.php
@@ -167,9 +167,7 @@ class InboundShipmentItemList implements ModelInterface, ArrayAccess, IterableTy
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FulfillmentInbound/InboundShipmentList.php
+++ b/lib/Models/FulfillmentInbound/InboundShipmentList.php
@@ -167,9 +167,7 @@ class InboundShipmentList implements ModelInterface, ArrayAccess, IterableType
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FulfillmentInbound/InboundShipmentPlanItemList.php
+++ b/lib/Models/FulfillmentInbound/InboundShipmentPlanItemList.php
@@ -167,9 +167,7 @@ class InboundShipmentPlanItemList implements ModelInterface, ArrayAccess, Iterab
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FulfillmentInbound/InboundShipmentPlanList.php
+++ b/lib/Models/FulfillmentInbound/InboundShipmentPlanList.php
@@ -167,9 +167,7 @@ class InboundShipmentPlanList implements ModelInterface, ArrayAccess, IterableTy
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FulfillmentInbound/InboundShipmentPlanRequestItemList.php
+++ b/lib/Models/FulfillmentInbound/InboundShipmentPlanRequestItemList.php
@@ -164,9 +164,7 @@ class InboundShipmentPlanRequestItemList implements ModelInterface, ArrayAccess,
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FulfillmentInbound/InboundShipmentResponse.php
+++ b/lib/Models/FulfillmentInbound/InboundShipmentResponse.php
@@ -173,9 +173,7 @@ class InboundShipmentResponse implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FulfillmentInbound/InvalidASIN.php
+++ b/lib/Models/FulfillmentInbound/InvalidASIN.php
@@ -170,9 +170,7 @@ class InvalidASIN implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FulfillmentInbound/InvalidASINList.php
+++ b/lib/Models/FulfillmentInbound/InvalidASINList.php
@@ -166,9 +166,7 @@ class InvalidASINList implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FulfillmentInbound/InvalidSKU.php
+++ b/lib/Models/FulfillmentInbound/InvalidSKU.php
@@ -170,9 +170,7 @@ class InvalidSKU implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FulfillmentInbound/InvalidSKUList.php
+++ b/lib/Models/FulfillmentInbound/InvalidSKUList.php
@@ -166,9 +166,7 @@ class InvalidSKUList implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FulfillmentInbound/LabelDownloadURL.php
+++ b/lib/Models/FulfillmentInbound/LabelDownloadURL.php
@@ -164,9 +164,7 @@ class LabelDownloadURL implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FulfillmentInbound/NonPartneredSmallParcelPackageInputList.php
+++ b/lib/Models/FulfillmentInbound/NonPartneredSmallParcelPackageInputList.php
@@ -167,9 +167,7 @@ class NonPartneredSmallParcelPackageInputList implements ModelInterface, ArrayAc
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FulfillmentInbound/NonPartneredSmallParcelPackageOutputList.php
+++ b/lib/Models/FulfillmentInbound/NonPartneredSmallParcelPackageOutputList.php
@@ -167,9 +167,7 @@ class NonPartneredSmallParcelPackageOutputList implements ModelInterface, ArrayA
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FulfillmentInbound/PalletList.php
+++ b/lib/Models/FulfillmentInbound/PalletList.php
@@ -166,9 +166,7 @@ class PalletList implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FulfillmentInbound/PartneredLtlDataInput.php
+++ b/lib/Models/FulfillmentInbound/PartneredLtlDataInput.php
@@ -203,9 +203,7 @@ class PartneredLtlDataInput implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FulfillmentInbound/PartneredSmallParcelDataInput.php
+++ b/lib/Models/FulfillmentInbound/PartneredSmallParcelDataInput.php
@@ -173,9 +173,7 @@ class PartneredSmallParcelDataInput implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FulfillmentInbound/PartneredSmallParcelPackageInputList.php
+++ b/lib/Models/FulfillmentInbound/PartneredSmallParcelPackageInputList.php
@@ -167,9 +167,7 @@ class PartneredSmallParcelPackageInputList implements ModelInterface, ArrayAcces
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FulfillmentInbound/PartneredSmallParcelPackageOutputList.php
+++ b/lib/Models/FulfillmentInbound/PartneredSmallParcelPackageOutputList.php
@@ -167,9 +167,7 @@ class PartneredSmallParcelPackageOutputList implements ModelInterface, ArrayAcce
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FulfillmentInbound/PrepDetailsList.php
+++ b/lib/Models/FulfillmentInbound/PrepDetailsList.php
@@ -167,9 +167,7 @@ class PrepDetailsList implements ModelInterface, ArrayAccess, IterableType
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FulfillmentInbound/PrepInstructionList.php
+++ b/lib/Models/FulfillmentInbound/PrepInstructionList.php
@@ -167,9 +167,7 @@ class PrepInstructionList implements ModelInterface, ArrayAccess, IterableType
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FulfillmentInbound/ProNumber.php
+++ b/lib/Models/FulfillmentInbound/ProNumber.php
@@ -166,9 +166,7 @@ class ProNumber implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FulfillmentInbound/PutTransportDetailsResponse.php
+++ b/lib/Models/FulfillmentInbound/PutTransportDetailsResponse.php
@@ -173,9 +173,7 @@ class PutTransportDetailsResponse implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FulfillmentInbound/Quantity.php
+++ b/lib/Models/FulfillmentInbound/Quantity.php
@@ -166,9 +166,7 @@ class Quantity implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FulfillmentInbound/SKUInboundGuidanceList.php
+++ b/lib/Models/FulfillmentInbound/SKUInboundGuidanceList.php
@@ -167,9 +167,7 @@ class SKUInboundGuidanceList implements ModelInterface, ArrayAccess, IterableTyp
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FulfillmentInbound/SKUPrepInstructions.php
+++ b/lib/Models/FulfillmentInbound/SKUPrepInstructions.php
@@ -197,9 +197,7 @@ class SKUPrepInstructions implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FulfillmentInbound/SKUPrepInstructionsList.php
+++ b/lib/Models/FulfillmentInbound/SKUPrepInstructionsList.php
@@ -167,9 +167,7 @@ class SKUPrepInstructionsList implements ModelInterface, ArrayAccess, IterableTy
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FulfillmentInbound/TimeStampStringType.php
+++ b/lib/Models/FulfillmentInbound/TimeStampStringType.php
@@ -163,9 +163,7 @@ class TimeStampStringType implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FulfillmentInbound/TrackingId.php
+++ b/lib/Models/FulfillmentInbound/TrackingId.php
@@ -166,9 +166,7 @@ class TrackingId implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FulfillmentInbound/TransportDetailInput.php
+++ b/lib/Models/FulfillmentInbound/TransportDetailInput.php
@@ -185,9 +185,7 @@ class TransportDetailInput implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FulfillmentInbound/TransportDetailOutput.php
+++ b/lib/Models/FulfillmentInbound/TransportDetailOutput.php
@@ -185,9 +185,7 @@ class TransportDetailOutput implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FulfillmentInbound/UnsignedIntType.php
+++ b/lib/Models/FulfillmentInbound/UnsignedIntType.php
@@ -163,9 +163,7 @@ class UnsignedIntType implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FulfillmentInbound/VoidTransportResponse.php
+++ b/lib/Models/FulfillmentInbound/VoidTransportResponse.php
@@ -173,9 +173,7 @@ class VoidTransportResponse implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FulfillmentOutbound/CancelFulfillmentOrderResponse.php
+++ b/lib/Models/FulfillmentOutbound/CancelFulfillmentOrderResponse.php
@@ -167,9 +167,7 @@ class CancelFulfillmentOrderResponse implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FulfillmentOutbound/CreateFulfillmentOrderItemList.php
+++ b/lib/Models/FulfillmentOutbound/CreateFulfillmentOrderItemList.php
@@ -167,9 +167,7 @@ class CreateFulfillmentOrderItemList implements ModelInterface, ArrayAccess, Ite
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FulfillmentOutbound/CreateFulfillmentOrderResponse.php
+++ b/lib/Models/FulfillmentOutbound/CreateFulfillmentOrderResponse.php
@@ -167,9 +167,7 @@ class CreateFulfillmentOrderResponse implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FulfillmentOutbound/CreateFulfillmentReturnResponse.php
+++ b/lib/Models/FulfillmentOutbound/CreateFulfillmentReturnResponse.php
@@ -173,9 +173,7 @@ class CreateFulfillmentReturnResponse implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FulfillmentOutbound/CreateFulfillmentReturnResult.php
+++ b/lib/Models/FulfillmentOutbound/CreateFulfillmentReturnResult.php
@@ -176,9 +176,7 @@ class CreateFulfillmentReturnResult implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FulfillmentOutbound/CreateReturnItemList.php
+++ b/lib/Models/FulfillmentOutbound/CreateReturnItemList.php
@@ -167,9 +167,7 @@ class CreateReturnItemList implements ModelInterface, ArrayAccess, IterableType
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FulfillmentOutbound/Decimal.php
+++ b/lib/Models/FulfillmentOutbound/Decimal.php
@@ -166,9 +166,7 @@ class Decimal implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FulfillmentOutbound/DeliveryWindowList.php
+++ b/lib/Models/FulfillmentOutbound/DeliveryWindowList.php
@@ -167,9 +167,7 @@ class DeliveryWindowList implements ModelInterface, ArrayAccess, IterableType
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FulfillmentOutbound/ErrorList.php
+++ b/lib/Models/FulfillmentOutbound/ErrorList.php
@@ -167,9 +167,7 @@ class ErrorList implements ModelInterface, ArrayAccess, IterableType
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FulfillmentOutbound/FeatureSku.php
+++ b/lib/Models/FulfillmentOutbound/FeatureSku.php
@@ -191,9 +191,7 @@ class FeatureSku implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FulfillmentOutbound/Features.php
+++ b/lib/Models/FulfillmentOutbound/Features.php
@@ -166,9 +166,7 @@ class Features implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FulfillmentOutbound/FeeList.php
+++ b/lib/Models/FulfillmentOutbound/FeeList.php
@@ -166,9 +166,7 @@ class FeeList implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FulfillmentOutbound/FulfillmentOrderItemList.php
+++ b/lib/Models/FulfillmentOutbound/FulfillmentOrderItemList.php
@@ -167,9 +167,7 @@ class FulfillmentOrderItemList implements ModelInterface, ArrayAccess, IterableT
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FulfillmentOutbound/FulfillmentPreviewItemList.php
+++ b/lib/Models/FulfillmentOutbound/FulfillmentPreviewItemList.php
@@ -167,9 +167,7 @@ class FulfillmentPreviewItemList implements ModelInterface, ArrayAccess, Iterabl
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FulfillmentOutbound/FulfillmentPreviewList.php
+++ b/lib/Models/FulfillmentOutbound/FulfillmentPreviewList.php
@@ -167,9 +167,7 @@ class FulfillmentPreviewList implements ModelInterface, ArrayAccess, IterableTyp
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FulfillmentOutbound/FulfillmentPreviewShipmentList.php
+++ b/lib/Models/FulfillmentOutbound/FulfillmentPreviewShipmentList.php
@@ -167,9 +167,7 @@ class FulfillmentPreviewShipmentList implements ModelInterface, ArrayAccess, Ite
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FulfillmentOutbound/FulfillmentShipmentItemList.php
+++ b/lib/Models/FulfillmentOutbound/FulfillmentShipmentItemList.php
@@ -167,9 +167,7 @@ class FulfillmentShipmentItemList implements ModelInterface, ArrayAccess, Iterab
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FulfillmentOutbound/FulfillmentShipmentList.php
+++ b/lib/Models/FulfillmentOutbound/FulfillmentShipmentList.php
@@ -167,9 +167,7 @@ class FulfillmentShipmentList implements ModelInterface, ArrayAccess, IterableTy
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FulfillmentOutbound/FulfillmentShipmentPackageList.php
+++ b/lib/Models/FulfillmentOutbound/FulfillmentShipmentPackageList.php
@@ -167,9 +167,7 @@ class FulfillmentShipmentPackageList implements ModelInterface, ArrayAccess, Ite
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FulfillmentOutbound/GetFeatureInventoryResponse.php
+++ b/lib/Models/FulfillmentOutbound/GetFeatureInventoryResponse.php
@@ -173,9 +173,7 @@ class GetFeatureInventoryResponse implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FulfillmentOutbound/GetFeatureSkuResponse.php
+++ b/lib/Models/FulfillmentOutbound/GetFeatureSkuResponse.php
@@ -173,9 +173,7 @@ class GetFeatureSkuResponse implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FulfillmentOutbound/GetFeaturesResponse.php
+++ b/lib/Models/FulfillmentOutbound/GetFeaturesResponse.php
@@ -173,9 +173,7 @@ class GetFeaturesResponse implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FulfillmentOutbound/GetFulfillmentOrderResponse.php
+++ b/lib/Models/FulfillmentOutbound/GetFulfillmentOrderResponse.php
@@ -173,9 +173,7 @@ class GetFulfillmentOrderResponse implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FulfillmentOutbound/GetFulfillmentPreviewItemList.php
+++ b/lib/Models/FulfillmentOutbound/GetFulfillmentPreviewItemList.php
@@ -167,9 +167,7 @@ class GetFulfillmentPreviewItemList implements ModelInterface, ArrayAccess, Iter
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FulfillmentOutbound/GetFulfillmentPreviewResponse.php
+++ b/lib/Models/FulfillmentOutbound/GetFulfillmentPreviewResponse.php
@@ -173,9 +173,7 @@ class GetFulfillmentPreviewResponse implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FulfillmentOutbound/GetFulfillmentPreviewResult.php
+++ b/lib/Models/FulfillmentOutbound/GetFulfillmentPreviewResult.php
@@ -167,9 +167,7 @@ class GetFulfillmentPreviewResult implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FulfillmentOutbound/GetPackageTrackingDetailsResponse.php
+++ b/lib/Models/FulfillmentOutbound/GetPackageTrackingDetailsResponse.php
@@ -173,9 +173,7 @@ class GetPackageTrackingDetailsResponse implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FulfillmentOutbound/InvalidReturnItemList.php
+++ b/lib/Models/FulfillmentOutbound/InvalidReturnItemList.php
@@ -167,9 +167,7 @@ class InvalidReturnItemList implements ModelInterface, ArrayAccess, IterableType
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FulfillmentOutbound/ListAllFulfillmentOrdersResponse.php
+++ b/lib/Models/FulfillmentOutbound/ListAllFulfillmentOrdersResponse.php
@@ -173,9 +173,7 @@ class ListAllFulfillmentOrdersResponse implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FulfillmentOutbound/ListAllFulfillmentOrdersResult.php
+++ b/lib/Models/FulfillmentOutbound/ListAllFulfillmentOrdersResult.php
@@ -170,9 +170,7 @@ class ListAllFulfillmentOrdersResult implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FulfillmentOutbound/ListReturnReasonCodesResponse.php
+++ b/lib/Models/FulfillmentOutbound/ListReturnReasonCodesResponse.php
@@ -173,9 +173,7 @@ class ListReturnReasonCodesResponse implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FulfillmentOutbound/ListReturnReasonCodesResult.php
+++ b/lib/Models/FulfillmentOutbound/ListReturnReasonCodesResult.php
@@ -164,9 +164,7 @@ class ListReturnReasonCodesResult implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FulfillmentOutbound/NotificationEmailList.php
+++ b/lib/Models/FulfillmentOutbound/NotificationEmailList.php
@@ -166,9 +166,7 @@ class NotificationEmailList implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FulfillmentOutbound/Quantity.php
+++ b/lib/Models/FulfillmentOutbound/Quantity.php
@@ -166,9 +166,7 @@ class Quantity implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FulfillmentOutbound/ReasonCodeDetailsList.php
+++ b/lib/Models/FulfillmentOutbound/ReasonCodeDetailsList.php
@@ -167,9 +167,7 @@ class ReasonCodeDetailsList implements ModelInterface, ArrayAccess, IterableType
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FulfillmentOutbound/ReturnAuthorizationList.php
+++ b/lib/Models/FulfillmentOutbound/ReturnAuthorizationList.php
@@ -167,9 +167,7 @@ class ReturnAuthorizationList implements ModelInterface, ArrayAccess, IterableTy
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FulfillmentOutbound/ReturnItemList.php
+++ b/lib/Models/FulfillmentOutbound/ReturnItemList.php
@@ -167,9 +167,7 @@ class ReturnItemList implements ModelInterface, ArrayAccess, IterableType
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FulfillmentOutbound/ShippingSpeedCategoryList.php
+++ b/lib/Models/FulfillmentOutbound/ShippingSpeedCategoryList.php
@@ -164,9 +164,7 @@ class ShippingSpeedCategoryList implements ModelInterface, ArrayAccess, Iterable
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FulfillmentOutbound/StringList.php
+++ b/lib/Models/FulfillmentOutbound/StringList.php
@@ -163,9 +163,7 @@ class StringList implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FulfillmentOutbound/Timestamp.php
+++ b/lib/Models/FulfillmentOutbound/Timestamp.php
@@ -163,9 +163,7 @@ class Timestamp implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FulfillmentOutbound/TrackingEventList.php
+++ b/lib/Models/FulfillmentOutbound/TrackingEventList.php
@@ -167,9 +167,7 @@ class TrackingEventList implements ModelInterface, ArrayAccess, IterableType
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FulfillmentOutbound/UnfulfillablePreviewItemList.php
+++ b/lib/Models/FulfillmentOutbound/UnfulfillablePreviewItemList.php
@@ -167,9 +167,7 @@ class UnfulfillablePreviewItemList implements ModelInterface, ArrayAccess, Itera
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FulfillmentOutbound/UpdateFulfillmentOrderItemList.php
+++ b/lib/Models/FulfillmentOutbound/UpdateFulfillmentOrderItemList.php
@@ -167,9 +167,7 @@ class UpdateFulfillmentOrderItemList implements ModelInterface, ArrayAccess, Ite
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FulfillmentOutbound/UpdateFulfillmentOrderRequest.php
+++ b/lib/Models/FulfillmentOutbound/UpdateFulfillmentOrderRequest.php
@@ -230,9 +230,7 @@ class UpdateFulfillmentOrderRequest implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/FulfillmentOutbound/UpdateFulfillmentOrderResponse.php
+++ b/lib/Models/FulfillmentOutbound/UpdateFulfillmentOrderResponse.php
@@ -167,9 +167,7 @@ class UpdateFulfillmentOrderResponse implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/MerchantFulfillment/AdditionalInputs.php
+++ b/lib/Models/MerchantFulfillment/AdditionalInputs.php
@@ -173,9 +173,7 @@ class AdditionalInputs implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/MerchantFulfillment/AdditionalInputsList.php
+++ b/lib/Models/MerchantFulfillment/AdditionalInputsList.php
@@ -167,9 +167,7 @@ class AdditionalInputsList implements ModelInterface, ArrayAccess, IterableType
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/MerchantFulfillment/AdditionalSellerInput.php
+++ b/lib/Models/MerchantFulfillment/AdditionalSellerInput.php
@@ -215,9 +215,7 @@ class AdditionalSellerInput implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/MerchantFulfillment/AdditionalSellerInputsList.php
+++ b/lib/Models/MerchantFulfillment/AdditionalSellerInputsList.php
@@ -167,9 +167,7 @@ class AdditionalSellerInputsList implements ModelInterface, ArrayAccess, Iterabl
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/MerchantFulfillment/AddressLine1.php
+++ b/lib/Models/MerchantFulfillment/AddressLine1.php
@@ -166,9 +166,7 @@ class AddressLine1 implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/MerchantFulfillment/AddressLine2.php
+++ b/lib/Models/MerchantFulfillment/AddressLine2.php
@@ -166,9 +166,7 @@ class AddressLine2 implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/MerchantFulfillment/AddressLine3.php
+++ b/lib/Models/MerchantFulfillment/AddressLine3.php
@@ -166,9 +166,7 @@ class AddressLine3 implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/MerchantFulfillment/AddressName.php
+++ b/lib/Models/MerchantFulfillment/AddressName.php
@@ -166,9 +166,7 @@ class AddressName implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/MerchantFulfillment/AmazonOrderId.php
+++ b/lib/Models/MerchantFulfillment/AmazonOrderId.php
@@ -166,9 +166,7 @@ class AmazonOrderId implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/MerchantFulfillment/AvailableCarrierWillPickUpOptionsList.php
+++ b/lib/Models/MerchantFulfillment/AvailableCarrierWillPickUpOptionsList.php
@@ -167,9 +167,7 @@ class AvailableCarrierWillPickUpOptionsList implements ModelInterface, ArrayAcce
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/MerchantFulfillment/AvailableDeliveryExperienceOptionsList.php
+++ b/lib/Models/MerchantFulfillment/AvailableDeliveryExperienceOptionsList.php
@@ -167,9 +167,7 @@ class AvailableDeliveryExperienceOptionsList implements ModelInterface, ArrayAcc
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/MerchantFulfillment/AvailableFormatOptionsForLabel.php
+++ b/lib/Models/MerchantFulfillment/AvailableFormatOptionsForLabel.php
@@ -163,9 +163,7 @@ class AvailableFormatOptionsForLabel implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/MerchantFulfillment/AvailableFormatOptionsForLabelList.php
+++ b/lib/Models/MerchantFulfillment/AvailableFormatOptionsForLabelList.php
@@ -167,9 +167,7 @@ class AvailableFormatOptionsForLabelList implements ModelInterface, ArrayAccess,
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/MerchantFulfillment/CancelShipmentResponse.php
+++ b/lib/Models/MerchantFulfillment/CancelShipmentResponse.php
@@ -173,9 +173,7 @@ class CancelShipmentResponse implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/MerchantFulfillment/City.php
+++ b/lib/Models/MerchantFulfillment/City.php
@@ -166,9 +166,7 @@ class City implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/MerchantFulfillment/Constraints.php
+++ b/lib/Models/MerchantFulfillment/Constraints.php
@@ -166,9 +166,7 @@ class Constraints implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/MerchantFulfillment/CountryCode.php
+++ b/lib/Models/MerchantFulfillment/CountryCode.php
@@ -166,9 +166,7 @@ class CountryCode implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/MerchantFulfillment/CreateShipmentResponse.php
+++ b/lib/Models/MerchantFulfillment/CreateShipmentResponse.php
@@ -173,9 +173,7 @@ class CreateShipmentResponse implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/MerchantFulfillment/CustomTextForLabel.php
+++ b/lib/Models/MerchantFulfillment/CustomTextForLabel.php
@@ -166,9 +166,7 @@ class CustomTextForLabel implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/MerchantFulfillment/DistrictOrCounty.php
+++ b/lib/Models/MerchantFulfillment/DistrictOrCounty.php
@@ -166,9 +166,7 @@ class DistrictOrCounty implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/MerchantFulfillment/EmailAddress.php
+++ b/lib/Models/MerchantFulfillment/EmailAddress.php
@@ -166,9 +166,7 @@ class EmailAddress implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/MerchantFulfillment/ErrorList.php
+++ b/lib/Models/MerchantFulfillment/ErrorList.php
@@ -167,9 +167,7 @@ class ErrorList implements ModelInterface, ArrayAccess, IterableType
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/MerchantFulfillment/GetAdditionalSellerInputsResponse.php
+++ b/lib/Models/MerchantFulfillment/GetAdditionalSellerInputsResponse.php
@@ -173,9 +173,7 @@ class GetAdditionalSellerInputsResponse implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/MerchantFulfillment/GetAdditionalSellerInputsResult.php
+++ b/lib/Models/MerchantFulfillment/GetAdditionalSellerInputsResult.php
@@ -173,9 +173,7 @@ class GetAdditionalSellerInputsResult implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/MerchantFulfillment/GetEligibleShipmentServicesResponse.php
+++ b/lib/Models/MerchantFulfillment/GetEligibleShipmentServicesResponse.php
@@ -173,9 +173,7 @@ class GetEligibleShipmentServicesResponse implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/MerchantFulfillment/GetShipmentResponse.php
+++ b/lib/Models/MerchantFulfillment/GetShipmentResponse.php
@@ -173,9 +173,7 @@ class GetShipmentResponse implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/MerchantFulfillment/ItemDescription.php
+++ b/lib/Models/MerchantFulfillment/ItemDescription.php
@@ -166,9 +166,7 @@ class ItemDescription implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/MerchantFulfillment/ItemLevelFieldsList.php
+++ b/lib/Models/MerchantFulfillment/ItemLevelFieldsList.php
@@ -167,9 +167,7 @@ class ItemLevelFieldsList implements ModelInterface, ArrayAccess, IterableType
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/MerchantFulfillment/ItemList.php
+++ b/lib/Models/MerchantFulfillment/ItemList.php
@@ -167,9 +167,7 @@ class ItemList implements ModelInterface, ArrayAccess, IterableType
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/MerchantFulfillment/ItemQuantity.php
+++ b/lib/Models/MerchantFulfillment/ItemQuantity.php
@@ -166,9 +166,7 @@ class ItemQuantity implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/MerchantFulfillment/LabelCustomization.php
+++ b/lib/Models/MerchantFulfillment/LabelCustomization.php
@@ -173,9 +173,7 @@ class LabelCustomization implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/MerchantFulfillment/LabelDimension.php
+++ b/lib/Models/MerchantFulfillment/LabelDimension.php
@@ -166,9 +166,7 @@ class LabelDimension implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/MerchantFulfillment/LabelFormatList.php
+++ b/lib/Models/MerchantFulfillment/LabelFormatList.php
@@ -167,9 +167,7 @@ class LabelFormatList implements ModelInterface, ArrayAccess, IterableType
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/MerchantFulfillment/LabelFormatOption.php
+++ b/lib/Models/MerchantFulfillment/LabelFormatOption.php
@@ -173,9 +173,7 @@ class LabelFormatOption implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/MerchantFulfillment/LabelFormatOptionRequest.php
+++ b/lib/Models/MerchantFulfillment/LabelFormatOptionRequest.php
@@ -167,9 +167,7 @@ class LabelFormatOptionRequest implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/MerchantFulfillment/Length.php
+++ b/lib/Models/MerchantFulfillment/Length.php
@@ -173,9 +173,7 @@ class Length implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/MerchantFulfillment/OrderItemId.php
+++ b/lib/Models/MerchantFulfillment/OrderItemId.php
@@ -166,9 +166,7 @@ class OrderItemId implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/MerchantFulfillment/PackageDimension.php
+++ b/lib/Models/MerchantFulfillment/PackageDimension.php
@@ -163,9 +163,7 @@ class PackageDimension implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/MerchantFulfillment/PackageDimensions.php
+++ b/lib/Models/MerchantFulfillment/PackageDimensions.php
@@ -191,9 +191,7 @@ class PackageDimensions implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/MerchantFulfillment/PhoneNumber.php
+++ b/lib/Models/MerchantFulfillment/PhoneNumber.php
@@ -166,9 +166,7 @@ class PhoneNumber implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/MerchantFulfillment/PostalCode.php
+++ b/lib/Models/MerchantFulfillment/PostalCode.php
@@ -166,9 +166,7 @@ class PostalCode implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/MerchantFulfillment/RejectedShippingServiceList.php
+++ b/lib/Models/MerchantFulfillment/RejectedShippingServiceList.php
@@ -167,9 +167,7 @@ class RejectedShippingServiceList implements ModelInterface, ArrayAccess, Iterab
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/MerchantFulfillment/RestrictedSetValues.php
+++ b/lib/Models/MerchantFulfillment/RestrictedSetValues.php
@@ -166,9 +166,7 @@ class RestrictedSetValues implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/MerchantFulfillment/SellerOrderId.php
+++ b/lib/Models/MerchantFulfillment/SellerOrderId.php
@@ -166,9 +166,7 @@ class SellerOrderId implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/MerchantFulfillment/ShipmentId.php
+++ b/lib/Models/MerchantFulfillment/ShipmentId.php
@@ -166,9 +166,7 @@ class ShipmentId implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/MerchantFulfillment/ShippingOfferingFilter.php
+++ b/lib/Models/MerchantFulfillment/ShippingOfferingFilter.php
@@ -185,9 +185,7 @@ class ShippingOfferingFilter implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/MerchantFulfillment/ShippingServiceIdentifier.php
+++ b/lib/Models/MerchantFulfillment/ShippingServiceIdentifier.php
@@ -166,9 +166,7 @@ class ShippingServiceIdentifier implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/MerchantFulfillment/ShippingServiceList.php
+++ b/lib/Models/MerchantFulfillment/ShippingServiceList.php
@@ -167,9 +167,7 @@ class ShippingServiceList implements ModelInterface, ArrayAccess, IterableType
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/MerchantFulfillment/StateOrProvinceCode.php
+++ b/lib/Models/MerchantFulfillment/StateOrProvinceCode.php
@@ -166,9 +166,7 @@ class StateOrProvinceCode implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/MerchantFulfillment/TemporarilyUnavailableCarrierList.php
+++ b/lib/Models/MerchantFulfillment/TemporarilyUnavailableCarrierList.php
@@ -167,9 +167,7 @@ class TemporarilyUnavailableCarrierList implements ModelInterface, ArrayAccess, 
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/MerchantFulfillment/TermsAndConditionsNotAcceptedCarrierList.php
+++ b/lib/Models/MerchantFulfillment/TermsAndConditionsNotAcceptedCarrierList.php
@@ -167,9 +167,7 @@ class TermsAndConditionsNotAcceptedCarrierList implements ModelInterface, ArrayA
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/MerchantFulfillment/Timestamp.php
+++ b/lib/Models/MerchantFulfillment/Timestamp.php
@@ -163,9 +163,7 @@ class Timestamp implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/MerchantFulfillment/TrackingId.php
+++ b/lib/Models/MerchantFulfillment/TrackingId.php
@@ -166,9 +166,7 @@ class TrackingId implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/MerchantFulfillment/TransparencyCode.php
+++ b/lib/Models/MerchantFulfillment/TransparencyCode.php
@@ -166,9 +166,7 @@ class TransparencyCode implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/MerchantFulfillment/TransparencyCodeList.php
+++ b/lib/Models/MerchantFulfillment/TransparencyCodeList.php
@@ -167,9 +167,7 @@ class TransparencyCodeList implements ModelInterface, ArrayAccess, IterableType
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/MerchantFulfillment/WeightValue.php
+++ b/lib/Models/MerchantFulfillment/WeightValue.php
@@ -166,9 +166,7 @@ class WeightValue implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Notifications/CreateDestinationResponse.php
+++ b/lib/Models/Notifications/CreateDestinationResponse.php
@@ -173,9 +173,7 @@ class CreateDestinationResponse implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Notifications/CreateSubscriptionRequest.php
+++ b/lib/Models/Notifications/CreateSubscriptionRequest.php
@@ -173,9 +173,7 @@ class CreateSubscriptionRequest implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Notifications/CreateSubscriptionResponse.php
+++ b/lib/Models/Notifications/CreateSubscriptionResponse.php
@@ -173,9 +173,7 @@ class CreateSubscriptionResponse implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Notifications/DeleteDestinationResponse.php
+++ b/lib/Models/Notifications/DeleteDestinationResponse.php
@@ -167,9 +167,7 @@ class DeleteDestinationResponse implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Notifications/DeleteSubscriptionByIdResponse.php
+++ b/lib/Models/Notifications/DeleteSubscriptionByIdResponse.php
@@ -167,9 +167,7 @@ class DeleteSubscriptionByIdResponse implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Notifications/DestinationList.php
+++ b/lib/Models/Notifications/DestinationList.php
@@ -167,9 +167,7 @@ class DestinationList implements ModelInterface, ArrayAccess, IterableType
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Notifications/DestinationResource.php
+++ b/lib/Models/Notifications/DestinationResource.php
@@ -173,9 +173,7 @@ class DestinationResource implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Notifications/DestinationResourceSpecification.php
+++ b/lib/Models/Notifications/DestinationResourceSpecification.php
@@ -173,9 +173,7 @@ class DestinationResourceSpecification implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Notifications/ErrorList.php
+++ b/lib/Models/Notifications/ErrorList.php
@@ -167,9 +167,7 @@ class ErrorList implements ModelInterface, ArrayAccess, IterableType
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Notifications/GetDestinationResponse.php
+++ b/lib/Models/Notifications/GetDestinationResponse.php
@@ -173,9 +173,7 @@ class GetDestinationResponse implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Notifications/GetDestinationsResponse.php
+++ b/lib/Models/Notifications/GetDestinationsResponse.php
@@ -173,9 +173,7 @@ class GetDestinationsResponse implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Notifications/GetSubscriptionByIdResponse.php
+++ b/lib/Models/Notifications/GetSubscriptionByIdResponse.php
@@ -173,9 +173,7 @@ class GetSubscriptionByIdResponse implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Notifications/GetSubscriptionResponse.php
+++ b/lib/Models/Notifications/GetSubscriptionResponse.php
@@ -173,9 +173,7 @@ class GetSubscriptionResponse implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Orders/BuyerCustomizedInfoDetail.php
+++ b/lib/Models/Orders/BuyerCustomizedInfoDetail.php
@@ -167,9 +167,7 @@ class BuyerCustomizedInfoDetail implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Orders/BuyerTaxInfo.php
+++ b/lib/Models/Orders/BuyerTaxInfo.php
@@ -179,9 +179,7 @@ class BuyerTaxInfo implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Orders/ErrorList.php
+++ b/lib/Models/Orders/ErrorList.php
@@ -167,9 +167,7 @@ class ErrorList implements ModelInterface, ArrayAccess, IterableType
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Orders/FulfillmentInstruction.php
+++ b/lib/Models/Orders/FulfillmentInstruction.php
@@ -167,9 +167,7 @@ class FulfillmentInstruction implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Orders/GetOrderAddressResponse.php
+++ b/lib/Models/Orders/GetOrderAddressResponse.php
@@ -173,9 +173,7 @@ class GetOrderAddressResponse implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Orders/GetOrderBuyerInfoResponse.php
+++ b/lib/Models/Orders/GetOrderBuyerInfoResponse.php
@@ -173,9 +173,7 @@ class GetOrderBuyerInfoResponse implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Orders/GetOrderItemsBuyerInfoResponse.php
+++ b/lib/Models/Orders/GetOrderItemsBuyerInfoResponse.php
@@ -173,9 +173,7 @@ class GetOrderItemsBuyerInfoResponse implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Orders/GetOrderItemsResponse.php
+++ b/lib/Models/Orders/GetOrderItemsResponse.php
@@ -173,9 +173,7 @@ class GetOrderItemsResponse implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Orders/GetOrderResponse.php
+++ b/lib/Models/Orders/GetOrderResponse.php
@@ -173,9 +173,7 @@ class GetOrderResponse implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Orders/GetOrdersResponse.php
+++ b/lib/Models/Orders/GetOrdersResponse.php
@@ -173,9 +173,7 @@ class GetOrdersResponse implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Orders/Money.php
+++ b/lib/Models/Orders/Money.php
@@ -173,9 +173,7 @@ class Money implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Orders/OrderItemBuyerInfoList.php
+++ b/lib/Models/Orders/OrderItemBuyerInfoList.php
@@ -167,9 +167,7 @@ class OrderItemBuyerInfoList implements ModelInterface, ArrayAccess, IterableTyp
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Orders/OrderItemList.php
+++ b/lib/Models/Orders/OrderItemList.php
@@ -167,9 +167,7 @@ class OrderItemList implements ModelInterface, ArrayAccess, IterableType
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Orders/OrderList.php
+++ b/lib/Models/Orders/OrderList.php
@@ -167,9 +167,7 @@ class OrderList implements ModelInterface, ArrayAccess, IterableType
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Orders/PaymentExecutionDetailItemList.php
+++ b/lib/Models/Orders/PaymentExecutionDetailItemList.php
@@ -167,9 +167,7 @@ class PaymentExecutionDetailItemList implements ModelInterface, ArrayAccess, Ite
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Orders/PaymentMethodDetailItemList.php
+++ b/lib/Models/Orders/PaymentMethodDetailItemList.php
@@ -166,9 +166,7 @@ class PaymentMethodDetailItemList implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Orders/PointsGrantedDetail.php
+++ b/lib/Models/Orders/PointsGrantedDetail.php
@@ -173,9 +173,7 @@ class PointsGrantedDetail implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Orders/ProductInfoDetail.php
+++ b/lib/Models/Orders/ProductInfoDetail.php
@@ -167,9 +167,7 @@ class ProductInfoDetail implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Orders/PromotionIdList.php
+++ b/lib/Models/Orders/PromotionIdList.php
@@ -166,9 +166,7 @@ class PromotionIdList implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Orders/TaxClassification.php
+++ b/lib/Models/Orders/TaxClassification.php
@@ -173,9 +173,7 @@ class TaxClassification implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/ProductFees/ErrorList.php
+++ b/lib/Models/ProductFees/ErrorList.php
@@ -167,9 +167,7 @@ class ErrorList implements ModelInterface, ArrayAccess, IterableType
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/ProductFees/FeeDetailList.php
+++ b/lib/Models/ProductFees/FeeDetailList.php
@@ -167,9 +167,7 @@ class FeeDetailList implements ModelInterface, ArrayAccess, IterableType
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/ProductFees/FeesEstimateErrorDetail.php
+++ b/lib/Models/ProductFees/FeesEstimateErrorDetail.php
@@ -166,9 +166,7 @@ class FeesEstimateErrorDetail implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/ProductFees/FeesEstimateIdentifier.php
+++ b/lib/Models/ProductFees/FeesEstimateIdentifier.php
@@ -203,9 +203,7 @@ class FeesEstimateIdentifier implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/ProductFees/FeesEstimateResult.php
+++ b/lib/Models/ProductFees/FeesEstimateResult.php
@@ -185,9 +185,7 @@ class FeesEstimateResult implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/ProductFees/GetMyFeesEstimateRequest.php
+++ b/lib/Models/ProductFees/GetMyFeesEstimateRequest.php
@@ -167,9 +167,7 @@ class GetMyFeesEstimateRequest implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/ProductFees/GetMyFeesEstimateResponse.php
+++ b/lib/Models/ProductFees/GetMyFeesEstimateResponse.php
@@ -170,9 +170,7 @@ class GetMyFeesEstimateResponse implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/ProductFees/GetMyFeesEstimateResult.php
+++ b/lib/Models/ProductFees/GetMyFeesEstimateResult.php
@@ -167,9 +167,7 @@ class GetMyFeesEstimateResult implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/ProductFees/IncludedFeeDetailList.php
+++ b/lib/Models/ProductFees/IncludedFeeDetailList.php
@@ -167,9 +167,7 @@ class IncludedFeeDetailList implements ModelInterface, ArrayAccess, IterableType
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/ProductFees/MoneyType.php
+++ b/lib/Models/ProductFees/MoneyType.php
@@ -170,9 +170,7 @@ class MoneyType implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/ProductFees/Points.php
+++ b/lib/Models/ProductFees/Points.php
@@ -170,9 +170,7 @@ class Points implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/ProductPricing/AttributeSetList.php
+++ b/lib/Models/ProductPricing/AttributeSetList.php
@@ -166,9 +166,7 @@ class AttributeSetList implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/ProductPricing/BuyBoxEligibleOffers.php
+++ b/lib/Models/ProductPricing/BuyBoxEligibleOffers.php
@@ -163,9 +163,7 @@ class BuyBoxEligibleOffers implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/ProductPricing/BuyBoxPrices.php
+++ b/lib/Models/ProductPricing/BuyBoxPrices.php
@@ -163,9 +163,7 @@ class BuyBoxPrices implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/ProductPricing/CompetitivePriceList.php
+++ b/lib/Models/ProductPricing/CompetitivePriceList.php
@@ -167,9 +167,7 @@ class CompetitivePriceList implements ModelInterface, ArrayAccess, IterableType
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/ProductPricing/ErrorList.php
+++ b/lib/Models/ProductPricing/ErrorList.php
@@ -167,9 +167,7 @@ class ErrorList implements ModelInterface, ArrayAccess, IterableType
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/ProductPricing/GetOffersResponse.php
+++ b/lib/Models/ProductPricing/GetOffersResponse.php
@@ -173,9 +173,7 @@ class GetOffersResponse implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/ProductPricing/GetPricingResponse.php
+++ b/lib/Models/ProductPricing/GetPricingResponse.php
@@ -173,9 +173,7 @@ class GetPricingResponse implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/ProductPricing/LowestPrices.php
+++ b/lib/Models/ProductPricing/LowestPrices.php
@@ -163,9 +163,7 @@ class LowestPrices implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/ProductPricing/MoneyType.php
+++ b/lib/Models/ProductPricing/MoneyType.php
@@ -170,9 +170,7 @@ class MoneyType implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/ProductPricing/NumberOfOfferListingsList.php
+++ b/lib/Models/ProductPricing/NumberOfOfferListingsList.php
@@ -167,9 +167,7 @@ class NumberOfOfferListingsList implements ModelInterface, ArrayAccess, Iterable
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/ProductPricing/NumberOfOffers.php
+++ b/lib/Models/ProductPricing/NumberOfOffers.php
@@ -163,9 +163,7 @@ class NumberOfOffers implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/ProductPricing/OfferCountType.php
+++ b/lib/Models/ProductPricing/OfferCountType.php
@@ -179,9 +179,7 @@ class OfferCountType implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/ProductPricing/OfferDetailList.php
+++ b/lib/Models/ProductPricing/OfferDetailList.php
@@ -164,9 +164,7 @@ class OfferDetailList implements ModelInterface, ArrayAccess, IterableType
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/ProductPricing/OffersList.php
+++ b/lib/Models/ProductPricing/OffersList.php
@@ -167,9 +167,7 @@ class OffersList implements ModelInterface, ArrayAccess, IterableType
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/ProductPricing/Points.php
+++ b/lib/Models/ProductPricing/Points.php
@@ -170,9 +170,7 @@ class Points implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/ProductPricing/PriceList.php
+++ b/lib/Models/ProductPricing/PriceList.php
@@ -164,9 +164,7 @@ class PriceList implements ModelInterface, ArrayAccess, IterableType
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/ProductPricing/RelationshipList.php
+++ b/lib/Models/ProductPricing/RelationshipList.php
@@ -166,9 +166,7 @@ class RelationshipList implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/ProductPricing/SalesRankList.php
+++ b/lib/Models/ProductPricing/SalesRankList.php
@@ -167,9 +167,7 @@ class SalesRankList implements ModelInterface, ArrayAccess, IterableType
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/ProductPricing/ShipsFromType.php
+++ b/lib/Models/ProductPricing/ShipsFromType.php
@@ -173,9 +173,7 @@ class ShipsFromType implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Reports/CancelReportResponse.php
+++ b/lib/Models/Reports/CancelReportResponse.php
@@ -167,9 +167,7 @@ class CancelReportResponse implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Reports/CancelReportScheduleResponse.php
+++ b/lib/Models/Reports/CancelReportScheduleResponse.php
@@ -167,9 +167,7 @@ class CancelReportScheduleResponse implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Reports/CreateReportResponse.php
+++ b/lib/Models/Reports/CreateReportResponse.php
@@ -173,9 +173,7 @@ class CreateReportResponse implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Reports/CreateReportScheduleResponse.php
+++ b/lib/Models/Reports/CreateReportScheduleResponse.php
@@ -173,9 +173,7 @@ class CreateReportScheduleResponse implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Reports/ErrorList.php
+++ b/lib/Models/Reports/ErrorList.php
@@ -167,9 +167,7 @@ class ErrorList implements ModelInterface, ArrayAccess, IterableType
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Reports/GetReportDocumentResponse.php
+++ b/lib/Models/Reports/GetReportDocumentResponse.php
@@ -173,9 +173,7 @@ class GetReportDocumentResponse implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Reports/GetReportResponse.php
+++ b/lib/Models/Reports/GetReportResponse.php
@@ -173,9 +173,7 @@ class GetReportResponse implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Reports/GetReportScheduleResponse.php
+++ b/lib/Models/Reports/GetReportScheduleResponse.php
@@ -173,9 +173,7 @@ class GetReportScheduleResponse implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Reports/GetReportSchedulesResponse.php
+++ b/lib/Models/Reports/GetReportSchedulesResponse.php
@@ -173,9 +173,7 @@ class GetReportSchedulesResponse implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Reports/GetReportsResponse.php
+++ b/lib/Models/Reports/GetReportsResponse.php
@@ -179,9 +179,7 @@ class GetReportsResponse implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Reports/ReportList.php
+++ b/lib/Models/Reports/ReportList.php
@@ -164,9 +164,7 @@ class ReportList implements ModelInterface, ArrayAccess, IterableType
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Reports/ReportOptions.php
+++ b/lib/Models/Reports/ReportOptions.php
@@ -166,9 +166,7 @@ class ReportOptions implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Reports/ReportScheduleList.php
+++ b/lib/Models/Reports/ReportScheduleList.php
@@ -164,9 +164,7 @@ class ReportScheduleList implements ModelInterface, ArrayAccess, IterableType
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Sales/Decimal.php
+++ b/lib/Models/Sales/Decimal.php
@@ -166,9 +166,7 @@ class Decimal implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Sales/ErrorList.php
+++ b/lib/Models/Sales/ErrorList.php
@@ -167,9 +167,7 @@ class ErrorList implements ModelInterface, ArrayAccess, IterableType
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Sales/GetOrderMetricsResponse.php
+++ b/lib/Models/Sales/GetOrderMetricsResponse.php
@@ -173,9 +173,7 @@ class GetOrderMetricsResponse implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Sales/OrderMetricsList.php
+++ b/lib/Models/Sales/OrderMetricsList.php
@@ -167,9 +167,7 @@ class OrderMetricsList implements ModelInterface, ArrayAccess, IterableType
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Sellers/ErrorList.php
+++ b/lib/Models/Sellers/ErrorList.php
@@ -167,9 +167,7 @@ class ErrorList implements ModelInterface, ArrayAccess, IterableType
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Sellers/GetMarketplaceParticipationsResponse.php
+++ b/lib/Models/Sellers/GetMarketplaceParticipationsResponse.php
@@ -173,9 +173,7 @@ class GetMarketplaceParticipationsResponse implements ModelInterface, ArrayAcces
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Sellers/MarketplaceParticipationList.php
+++ b/lib/Models/Sellers/MarketplaceParticipationList.php
@@ -167,9 +167,7 @@ class MarketplaceParticipationList implements ModelInterface, ArrayAccess, Itera
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Services/AppointmentId.php
+++ b/lib/Models/Services/AppointmentId.php
@@ -166,9 +166,7 @@ class AppointmentId implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Services/Buyer.php
+++ b/lib/Models/Services/Buyer.php
@@ -185,9 +185,7 @@ class Buyer implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Services/CancelServiceJobByServiceJobIdResponse.php
+++ b/lib/Models/Services/CancelServiceJobByServiceJobIdResponse.php
@@ -167,9 +167,7 @@ class CancelServiceJobByServiceJobIdResponse implements ModelInterface, ArrayAcc
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Services/CompleteServiceJobByServiceJobIdResponse.php
+++ b/lib/Models/Services/CompleteServiceJobByServiceJobIdResponse.php
@@ -167,9 +167,7 @@ class CompleteServiceJobByServiceJobIdResponse implements ModelInterface, ArrayA
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Services/ErrorList.php
+++ b/lib/Models/Services/ErrorList.php
@@ -167,9 +167,7 @@ class ErrorList implements ModelInterface, ArrayAccess, IterableType
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Services/GetServiceJobByServiceJobIdResponse.php
+++ b/lib/Models/Services/GetServiceJobByServiceJobIdResponse.php
@@ -173,9 +173,7 @@ class GetServiceJobByServiceJobIdResponse implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Services/GetServiceJobsResponse.php
+++ b/lib/Models/Services/GetServiceJobsResponse.php
@@ -173,9 +173,7 @@ class GetServiceJobsResponse implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Services/ItemDelivery.php
+++ b/lib/Models/Services/ItemDelivery.php
@@ -173,9 +173,7 @@ class ItemDelivery implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Services/ItemDeliveryPromise.php
+++ b/lib/Models/Services/ItemDeliveryPromise.php
@@ -173,9 +173,7 @@ class ItemDeliveryPromise implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Services/JobListing.php
+++ b/lib/Models/Services/JobListing.php
@@ -185,9 +185,7 @@ class JobListing implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Services/OrderId.php
+++ b/lib/Models/Services/OrderId.php
@@ -166,9 +166,7 @@ class OrderId implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Services/RescheduleReasonCode.php
+++ b/lib/Models/Services/RescheduleReasonCode.php
@@ -166,9 +166,7 @@ class RescheduleReasonCode implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Services/ScopeOfWork.php
+++ b/lib/Models/Services/ScopeOfWork.php
@@ -185,9 +185,7 @@ class ScopeOfWork implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Services/Seller.php
+++ b/lib/Models/Services/Seller.php
@@ -167,9 +167,7 @@ class Seller implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Services/ServiceJobId.php
+++ b/lib/Models/Services/ServiceJobId.php
@@ -166,9 +166,7 @@ class ServiceJobId implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Services/ServiceJobProvider.php
+++ b/lib/Models/Services/ServiceJobProvider.php
@@ -167,9 +167,7 @@ class ServiceJobProvider implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Services/SetAppointmentResponse.php
+++ b/lib/Models/Services/SetAppointmentResponse.php
@@ -179,9 +179,7 @@ class SetAppointmentResponse implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Services/Technician.php
+++ b/lib/Models/Services/Technician.php
@@ -173,9 +173,7 @@ class Technician implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Services/WarningList.php
+++ b/lib/Models/Services/WarningList.php
@@ -167,9 +167,7 @@ class WarningList implements ModelInterface, ArrayAccess, IterableType
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Shipping/AcceptedRate.php
+++ b/lib/Models/Shipping/AcceptedRate.php
@@ -185,9 +185,7 @@ class AcceptedRate implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Shipping/AccountId.php
+++ b/lib/Models/Shipping/AccountId.php
@@ -166,9 +166,7 @@ class AccountId implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Shipping/CancelShipmentResponse.php
+++ b/lib/Models/Shipping/CancelShipmentResponse.php
@@ -167,9 +167,7 @@ class CancelShipmentResponse implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Shipping/City.php
+++ b/lib/Models/Shipping/City.php
@@ -166,9 +166,7 @@ class City implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Shipping/ClientReferenceId.php
+++ b/lib/Models/Shipping/ClientReferenceId.php
@@ -166,9 +166,7 @@ class ClientReferenceId implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Shipping/ContainerList.php
+++ b/lib/Models/Shipping/ContainerList.php
@@ -167,9 +167,7 @@ class ContainerList implements ModelInterface, ArrayAccess, IterableType
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Shipping/ContainerReferenceId.php
+++ b/lib/Models/Shipping/ContainerReferenceId.php
@@ -166,9 +166,7 @@ class ContainerReferenceId implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Shipping/ContainerSpecificationList.php
+++ b/lib/Models/Shipping/ContainerSpecificationList.php
@@ -167,9 +167,7 @@ class ContainerSpecificationList implements ModelInterface, ArrayAccess, Iterabl
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Shipping/CountryCode.php
+++ b/lib/Models/Shipping/CountryCode.php
@@ -166,9 +166,7 @@ class CountryCode implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Shipping/CreateShipmentResponse.php
+++ b/lib/Models/Shipping/CreateShipmentResponse.php
@@ -173,9 +173,7 @@ class CreateShipmentResponse implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Shipping/ErrorList.php
+++ b/lib/Models/Shipping/ErrorList.php
@@ -167,9 +167,7 @@ class ErrorList implements ModelInterface, ArrayAccess, IterableType
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Shipping/EventCode.php
+++ b/lib/Models/Shipping/EventCode.php
@@ -166,9 +166,7 @@ class EventCode implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Shipping/EventList.php
+++ b/lib/Models/Shipping/EventList.php
@@ -167,9 +167,7 @@ class EventList implements ModelInterface, ArrayAccess, IterableType
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Shipping/GetAccountResponse.php
+++ b/lib/Models/Shipping/GetAccountResponse.php
@@ -173,9 +173,7 @@ class GetAccountResponse implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Shipping/GetRatesResponse.php
+++ b/lib/Models/Shipping/GetRatesResponse.php
@@ -173,9 +173,7 @@ class GetRatesResponse implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Shipping/GetShipmentResponse.php
+++ b/lib/Models/Shipping/GetShipmentResponse.php
@@ -173,9 +173,7 @@ class GetShipmentResponse implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Shipping/GetTrackingInformationResponse.php
+++ b/lib/Models/Shipping/GetTrackingInformationResponse.php
@@ -173,9 +173,7 @@ class GetTrackingInformationResponse implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Shipping/Label.php
+++ b/lib/Models/Shipping/Label.php
@@ -173,9 +173,7 @@ class Label implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Shipping/LabelResult.php
+++ b/lib/Models/Shipping/LabelResult.php
@@ -179,9 +179,7 @@ class LabelResult implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Shipping/LabelResultList.php
+++ b/lib/Models/Shipping/LabelResultList.php
@@ -167,9 +167,7 @@ class LabelResultList implements ModelInterface, ArrayAccess, IterableType
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Shipping/LabelStream.php
+++ b/lib/Models/Shipping/LabelStream.php
@@ -166,9 +166,7 @@ class LabelStream implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Shipping/Location.php
+++ b/lib/Models/Shipping/Location.php
@@ -185,9 +185,7 @@ class Location implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Shipping/Party.php
+++ b/lib/Models/Shipping/Party.php
@@ -167,9 +167,7 @@ class Party implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Shipping/PostalCode.php
+++ b/lib/Models/Shipping/PostalCode.php
@@ -166,9 +166,7 @@ class PostalCode implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Shipping/PromisedDeliveryDate.php
+++ b/lib/Models/Shipping/PromisedDeliveryDate.php
@@ -166,9 +166,7 @@ class PromisedDeliveryDate implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Shipping/PurchaseLabelsResponse.php
+++ b/lib/Models/Shipping/PurchaseLabelsResponse.php
@@ -173,9 +173,7 @@ class PurchaseLabelsResponse implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Shipping/PurchaseShipmentResponse.php
+++ b/lib/Models/Shipping/PurchaseShipmentResponse.php
@@ -173,9 +173,7 @@ class PurchaseShipmentResponse implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Shipping/Rate.php
+++ b/lib/Models/Shipping/Rate.php
@@ -197,9 +197,7 @@ class Rate implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Shipping/RateId.php
+++ b/lib/Models/Shipping/RateId.php
@@ -166,9 +166,7 @@ class RateId implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Shipping/RateList.php
+++ b/lib/Models/Shipping/RateList.php
@@ -167,9 +167,7 @@ class RateList implements ModelInterface, ArrayAccess, IterableType
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Shipping/RetrieveShippingLabelResponse.php
+++ b/lib/Models/Shipping/RetrieveShippingLabelResponse.php
@@ -173,9 +173,7 @@ class RetrieveShippingLabelResponse implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Shipping/ServiceRateList.php
+++ b/lib/Models/Shipping/ServiceRateList.php
@@ -167,9 +167,7 @@ class ServiceRateList implements ModelInterface, ArrayAccess, IterableType
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Shipping/ServiceTypeList.php
+++ b/lib/Models/Shipping/ServiceTypeList.php
@@ -167,9 +167,7 @@ class ServiceTypeList implements ModelInterface, ArrayAccess, IterableType
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Shipping/ShipmentId.php
+++ b/lib/Models/Shipping/ShipmentId.php
@@ -166,9 +166,7 @@ class ShipmentId implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Shipping/ShippingPromiseSet.php
+++ b/lib/Models/Shipping/ShippingPromiseSet.php
@@ -173,9 +173,7 @@ class ShippingPromiseSet implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Shipping/StateOrRegion.php
+++ b/lib/Models/Shipping/StateOrRegion.php
@@ -166,9 +166,7 @@ class StateOrRegion implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Shipping/TimeRange.php
+++ b/lib/Models/Shipping/TimeRange.php
@@ -173,9 +173,7 @@ class TimeRange implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Shipping/TrackingId.php
+++ b/lib/Models/Shipping/TrackingId.php
@@ -166,9 +166,7 @@ class TrackingId implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Shipping/TrackingSummary.php
+++ b/lib/Models/Shipping/TrackingSummary.php
@@ -167,9 +167,7 @@ class TrackingSummary implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Solicitations/CreateProductReviewAndSellerFeedbackSolicitationResponse.php
+++ b/lib/Models/Solicitations/CreateProductReviewAndSellerFeedbackSolicitationResponse.php
@@ -167,9 +167,7 @@ class CreateProductReviewAndSellerFeedbackSolicitationResponse implements ModelI
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Solicitations/ErrorList.php
+++ b/lib/Models/Solicitations/ErrorList.php
@@ -167,9 +167,7 @@ class ErrorList implements ModelInterface, ArrayAccess, IterableType
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Solicitations/GetSchemaResponse.php
+++ b/lib/Models/Solicitations/GetSchemaResponse.php
@@ -176,9 +176,7 @@ class GetSchemaResponse implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Solicitations/GetSolicitationActionResponse.php
+++ b/lib/Models/Solicitations/GetSolicitationActionResponse.php
@@ -185,9 +185,7 @@ class GetSolicitationActionResponse implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Solicitations/GetSolicitationActionResponseEmbedded.php
+++ b/lib/Models/Solicitations/GetSolicitationActionResponseEmbedded.php
@@ -164,9 +164,7 @@ class GetSolicitationActionResponseEmbedded implements ModelInterface, ArrayAcce
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Solicitations/GetSolicitationActionsForOrderResponse.php
+++ b/lib/Models/Solicitations/GetSolicitationActionsForOrderResponse.php
@@ -179,9 +179,7 @@ class GetSolicitationActionsForOrderResponse implements ModelInterface, ArrayAcc
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Models/Solicitations/Schema.php
+++ b/lib/Models/Solicitations/Schema.php
@@ -166,9 +166,7 @@ class Schema implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
-
-        return $invalidProperties;
+        return [];
     }
 
     /**


### PR DESCRIPTION
- Removed 'parent::listInvalidProperties' that will thrown an exception since the class has no inheritance.
- Removed useless/redundant '$invalidProperties' declaration.
